### PR TITLE
docs: contributing guidelines

### DIFF
--- a/.github/workflows/pr_testing.yml
+++ b/.github/workflows/pr_testing.yml
@@ -1,0 +1,12 @@
+name: Test Suites for PR
+on:
+  pull_request:
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v5

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,15 @@
+name: Create Tag for Terraform Registry
+on:
+  push:
+    branches:
+      - main
+jobs:
+  add-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing
+
+Thank you for contributing!
+
+<a href="https://github.com/FormidableLabs/terraform-aws-platform#maintenance-status">
+  <img alt="Maintenance Status" src="https://img.shields.io/badge/maintenance-active-green.svg" />
+</a>
+
+`terraform-aws-lambda` is actively maintained by [@FormidableLabs][formidable-github].
+
+## Commit Messages
+
+The versioning scheme we use is [SemVer](http://semver.org/) and all commit messages must adhere to the [semantic-release](https://semantic-release.gitbook.io/semantic-release/#commit-message-format) format.
+
+The `Check commit messages are in commitlint format` step will fail any Pull Requests not in this format. Please follow [these steps](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message) to change your commit message and re-push.
+
+For any Breaking Releases (aka Major releases), the words `BREAKING CHANGE: ` **must** be in the footer of the commit message and Pull Request message. This can be achieved with `git commit -m "feat: code change" -m "BREAKING CHANGE: service upgrade"`
+
+For any Feature Releases (aka Minor releases), the commit message will need to begin with `feat:`
+
+For any Fix Releases (aka Patch releases), the commit message can begin with any of the following `build:|ci:|docs:|fix:|perf:|refactor:|test:`. `fix:` is typically the most common.
+
+## Contributor Covenant Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at coc@formidable.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][cc-homepage], version 2.0,
+available at [https://www.contributor-covenant.org/version/2/0][cc-latest-version]
+
+<!-- Links -->
+
+[cc-homepage]: http://contributor-covenant.org
+[cc-latest-version]: https://www.contributor-covenant.org/version/2/0/code_of_conduct
+[formidable-github]: https://www.github.com/FormidableLabs


### PR DESCRIPTION
- CONTRIBUTING.md setup
- Setup of `tag_release.yml` GitHub Action - this will create a new tag per merge to `main`
- Setup of `commitlint` GitHub Action check - this is to ensure that commit messages are in the appropriate format in order for new semver tags to be created successfully